### PR TITLE
refactor: remove dead code and eliminate redundant state extraction

### DIFF
--- a/src/spec_kitty_events/gates.py
+++ b/src/spec_kitty_events/gates.py
@@ -117,9 +117,6 @@ _CONCLUSION_MAP: dict[str, Optional[str]] = {
     "stale": None,
 }
 
-_IGNORED_CONCLUSIONS = frozenset({"neutral", "skipped", "stale"})
-
-
 def map_check_run_conclusion(
     conclusion: str,
     on_ignored: Optional[Callable[[str, str], None]] = None,
@@ -146,7 +143,7 @@ def map_check_run_conclusion(
 
     event_type = _CONCLUSION_MAP[conclusion]
 
-    if conclusion in _IGNORED_CONCLUSIONS:
+    if event_type is None:
         logger.info(
             "Ignored non-blocking check_run conclusion: %s", conclusion
         )

--- a/src/spec_kitty_events/merge.py
+++ b/src/spec_kitty_events/merge.py
@@ -52,9 +52,9 @@ def state_machine_merge(
                 f"Events have different aggregate_ids: {event.aggregate_id} != {first_event.aggregate_id}"
             )
 
-    def _get_state(event: Event) -> object:
+    def _get_state(event: Event) -> str | None:
         """Extract state value from event payload with fallback logic."""
-        value = event.payload.get(state_key)
+        value: str | None = event.payload.get(state_key)
         if value is None and state_key == "state":
             value = event.payload.get("status")
         return value

--- a/src/spec_kitty_events/merge.py
+++ b/src/spec_kitty_events/merge.py
@@ -52,13 +52,17 @@ def state_machine_merge(
                 f"Events have different aggregate_ids: {event.aggregate_id} != {first_event.aggregate_id}"
             )
 
+    def _get_state(event: Event) -> object:
+        """Extract state value from event payload with fallback logic."""
+        value = event.payload.get(state_key)
+        if value is None and state_key == "state":
+            value = event.payload.get("status")
+        return value
+
     # Extract state values and validate against priority_map
     event_priorities: List[tuple[int, str, Event]] = []
     for event in events:
-        state_value = event.payload.get(state_key)
-        # Fallback to "status" if using default "state" key and "state" not found
-        if state_value is None and state_key == "state":
-            state_value = event.payload.get("status")
+        state_value = _get_state(event)
         if state_value is None:
             keys_tried = f"'{state_key}' or 'status'" if state_key == "state" else f"'{state_key}'"
             raise ValidationError(f"Event {event.event_id} missing {keys_tried} in payload")
@@ -75,21 +79,13 @@ def state_machine_merge(
 
     # Winner is first event after sorting
     winner_priority, winner_node_id, winner_event = event_priorities[0]
-    winner_state = winner_event.payload.get(state_key)
-    if winner_state is None and state_key == "state":
-        winner_state = winner_event.payload.get("status")
+    winner_state = _get_state(winner_event)
 
     # Build resolution note
     if len(events) == 1:
         resolution_note = f"Single event, no conflict: state={winner_state}"
     else:
-        # Extract states with same fallback logic
-        all_states = []
-        for e in events:
-            s = e.payload.get(state_key)
-            if s is None and state_key == "state":
-                s = e.payload.get("status")
-            all_states.append(s)
+        all_states = [_get_state(e) for e in events]
         unique_states = set(all_states)
         if len(unique_states) == 1:
             resolution_note = f"All events have same state: {winner_state} (tiebroken by node '{winner_node_id}')"

--- a/src/spec_kitty_events/mission_audit.py
+++ b/src/spec_kitty_events/mission_audit.py
@@ -257,15 +257,6 @@ def reduce_mission_audit_events(events: Sequence[Event]) -> ReducedMissionAuditS
         event_id = event.event_id
         payload_dict = event.payload if isinstance(event.payload, dict) else {}
 
-        # Anomaly: unrecognized event type (within family — defensive)
-        if event_type not in MISSION_AUDIT_EVENT_TYPES:
-            anomalies_list.append(MissionAuditAnomaly(
-                kind="unrecognized_event_type",
-                event_id=event_id,
-                message=f"Unrecognized event type in audit family: {event_type!r}",
-            ))
-            continue
-
         # Anomaly: event after terminal
         if terminal_seen:
             anomalies_list.append(MissionAuditAnomaly(


### PR DESCRIPTION
## Summary

Three isolated, low-risk simplifications that remove dead code and eliminate redundant patterns. All 1481 tests pass with no public API changes.

### Changes

1. **`merge.py` -- Extract duplicated state-extraction into helper**
   - The state-value-with-fallback pattern (`payload.get(state_key)` falling back to `payload.get("status")`) was copy-pasted 3 times in `state_machine_merge()` and had to stay manually in sync
   - Extracted into a local `_get_state()` helper, reducing the 3 copies to 1 source of truth
   - **Low risk**: Change is internal to one private function; no public API change
   - **High impact**: Eliminates copy-paste maintenance burden and reduces bug surface for fallback logic drift

2. **`gates.py` -- Remove redundant `_IGNORED_CONCLUSIONS` frozenset**
   - `_IGNORED_CONCLUSIONS = frozenset({"neutral", "skipped", "stale"})` duplicated information already encoded in `_CONCLUSION_MAP` (keys that map to `None`)
   - Replaced `conclusion in _IGNORED_CONCLUSIONS` with `event_type is None`, which derives the answer from `_CONCLUSION_MAP` directly
   - **Low risk**: Removed a private module-level variable; the public function `map_check_run_conclusion()` is behaviorally identical
   - **High impact**: Eliminates dual-maintenance risk -- if someone adds a new ignored conclusion to `_CONCLUSION_MAP` but forgets to update `_IGNORED_CONCLUSIONS`, behavior would silently diverge

3. **`mission_audit.py` -- Remove unreachable dead code in reducer**
   - The "unrecognized event type" check (`if event_type not in MISSION_AUDIT_EVENT_TYPES`) could never fire because the reducer loop iterates over `audit_events`, which was already filtered to only include `MISSION_AUDIT_EVENT_TYPES` events 6 lines earlier
   - **Low risk**: Code was provably unreachable; removing it changes nothing at runtime
   - **High impact**: Dead code misleads maintainers into thinking the check is meaningful; removing it clarifies the actual control flow

### What was NOT changed (and why)

- **DecisionPoint payload classes (4 identical copies)**: Refactoring to a base class would change the public API type hierarchy, affecting downstream `isinstance` checks and JSON schema generation. HIGH RISK.
- **Connector payload classes (7 classes with shared fields)**: Same reasoning as above. HIGH RISK.
- **Late imports in `collaboration.py` / `lifecycle.py`**: While no known consumer imports `Event` from these modules, removing module-level names could break unknown downstream code. MEDIUM RISK, LOW IMPACT.

## Test plan

- [x] All 1481 existing tests pass (`pytest tests/ -x -q`)
- [x] Coverage stable at 97% (slightly improved: 2561 lines vs 2569 before, 72 uncovered vs 74)
- [x] No public API changes -- `__all__` exports unchanged
- [x] Each change is isolated to a single file with no cross-module dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)