### PR TITLE
Add canonical acceptance workflow

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,0 +1,89 @@
+name: Acceptance
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main, develop]
+  workflow_dispatch:
+    inputs:
+      candidate_package:
+        description: Optional candidate package under verification
+        required: false
+        default: ""
+        type: string
+      candidate_version:
+        description: Optional candidate version under verification
+        required: false
+        default: ""
+        type: string
+      candidate_source:
+        description: Optional candidate source descriptor
+        required: false
+        default: ""
+        type: string
+      candidate_ref:
+        description: Optional candidate git ref or artifact identifier
+        required: false
+        default: ""
+        type: string
+      verification_profile:
+        description: Verification profile name
+        required: false
+        default: default
+        type: string
+  workflow_call:
+    inputs:
+      candidate_package:
+        required: false
+        type: string
+        default: ""
+      candidate_version:
+        required: false
+        type: string
+        default: ""
+      candidate_source:
+        required: false
+        type: string
+        default: ""
+      candidate_ref:
+        required: false
+        type: string
+        default: ""
+      verification_profile:
+        required: false
+        type: string
+        default: default
+
+concurrency:
+  group: acceptance-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  acceptance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test and build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,conformance]" build
+
+      - name: Run pytest
+        run: pytest --cov --cov-report=xml
+
+      - name: Run mypy
+        run: mypy src/spec_kitty_events --strict
+
+      - name: Build package artifacts
+        run: python -m build --sdist --wheel

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -7,7 +7,13 @@ on:
   workflow_dispatch:
 
 jobs:
+  acceptance:
+    uses: ./.github/workflows/acceptance.yml
+    with:
+      verification_profile: release
+
   build:
+    needs: acceptance
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -4,7 +4,13 @@ on:
   workflow_dispatch:
 
 jobs:
+  acceptance:
+    uses: ./.github/workflows/acceptance.yml
+    with:
+      verification_profile: release
+
   build:
+    needs: acceptance
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Summary

Adds a canonical `.github/workflows/acceptance.yml` to `spec-kitty-events` and makes the publish workflows depend on that canonical package acceptance gate.

## What changed

- add `.github/workflows/acceptance.yml`
- make `publish-testpypi.yml` depend on the acceptance workflow
- make `publish-pypi.yml` depend on the acceptance workflow

## Why

This is the phase-1 implementation for #8 and the planning work in local commit `b5379d3`.

The aim is to stop treating publish as the first meaningful validation point and instead expose one reusable acceptance surface that downstream consumer verification can build on.

## Validation

- parsed touched workflow YAML successfully with Ruby's YAML loader
