### PR TITLE
Honor forced status transitions and accept structured actors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-events"
-version = "3.1.0"
+version = "3.2.0"
 description = "Event log library with Lamport clocks and systematic error tracking"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/spec_kitty_events/__init__.py
+++ b/src/spec_kitty_events/__init__.py
@@ -8,7 +8,7 @@ This release publishes the fail-closed cutover surface for:
 - authoritative artifact-driven compatibility gating via ``spec_kitty_events.cutover``
 """
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"
 
 from spec_kitty_events.cutover import (
     CUTOVER_ARTIFACT,

--- a/src/spec_kitty_events/retrospective.py
+++ b/src/spec_kitty_events/retrospective.py
@@ -37,6 +37,20 @@ TriggerSourceT = Literal["runtime", "operator", "policy"]
 # ── Section 4: Payload Models ────────────────────────────────────────────────
 
 
+def _assert_iso8601_timestamp(value: object) -> object:
+    """Validate an ISO 8601 timestamp across supported Python runtimes.
+
+    Python 3.10's ``datetime.fromisoformat`` rejects a trailing ``Z`` even
+    though the fixtures and contract use the RFC 3339 UTC form. Normalize that
+    case to ``+00:00`` before parsing.
+    """
+
+    if isinstance(value, str):
+        normalized = f"{value[:-1]}+00:00" if value.endswith("Z") else value
+        datetime.fromisoformat(normalized)
+    return value
+
+
 class RetrospectiveCompletedPayload(BaseModel):
     """Payload for RetrospectiveCompleted events.
 
@@ -60,9 +74,7 @@ class RetrospectiveCompletedPayload(BaseModel):
     @field_validator("completed_at", mode="before")
     @classmethod
     def _validate_completed_at_iso8601(cls, v: object) -> object:
-        if isinstance(v, str):
-            datetime.fromisoformat(v)
-        return v
+        return _assert_iso8601_timestamp(v)
 
 
 class RetrospectiveSkippedPayload(BaseModel):
@@ -88,6 +100,4 @@ class RetrospectiveSkippedPayload(BaseModel):
     @field_validator("skipped_at", mode="before")
     @classmethod
     def _validate_skipped_at_iso8601(cls, v: object) -> object:
-        if isinstance(v, str):
-            datetime.fromisoformat(v)
-        return v
+        return _assert_iso8601_timestamp(v)

--- a/src/spec_kitty_events/schemas/status_transition_payload.schema.json
+++ b/src/spec_kitty_events/schemas/status_transition_payload.schema.json
@@ -181,10 +181,17 @@
   "description": "Payload for a WPStatusChanged event describing a lane transition.",
   "properties": {
     "actor": {
-      "description": "Who initiated the transition",
-      "minLength": 1,
-      "title": "Actor",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "additionalProperties": true,
+          "type": "object"
+        }
+      ],
+      "description": "Who initiated the transition. Accepts either a plain string identifier (e.g. 'claude', 'user', 'migration') or a structured dict carrying richer audit fields such as {role, profile, tool, model}. Use ``actor_label`` for a canonical string form.",
+      "title": "Actor"
     },
     "evidence": {
       "anyOf": [

--- a/src/spec_kitty_events/status.py
+++ b/src/spec_kitty_events/status.py
@@ -1,14 +1,17 @@
 """Status state model contracts for work-package lane transitions."""
 
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from types import MappingProxyType
-from typing import Dict, FrozenSet, List, Literal, Mapping, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, FrozenSet, List, Literal, Mapping, Optional, Sequence, Set, Tuple, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from spec_kitty_events.models import Event, SpecKittyEventsError, ValidationError
+
+logger = logging.getLogger(__name__)
 
 
 class Lane(str, Enum):
@@ -210,7 +213,15 @@ class StatusTransitionPayload(BaseModel):
         None, description="Lane the WP is transitioning from (None for initial)"
     )
     to_lane: Lane = Field(..., description="Lane the WP is transitioning to")
-    actor: str = Field(..., min_length=1, description="Who initiated the transition")
+    actor: Union[str, Dict[str, Any]] = Field(
+        ...,
+        description=(
+            "Who initiated the transition. Accepts either a plain string identifier "
+            "(e.g. 'claude', 'user', 'migration') or a structured dict carrying "
+            "richer audit fields such as {role, profile, tool, model}. Use "
+            "``actor_label`` for a canonical string form."
+        ),
+    )
     force: bool = Field(False, description="Whether this is a forced transition")
     reason: Optional[str] = Field(
         None, description="Reason for the transition (required when force=True)"
@@ -234,6 +245,43 @@ class StatusTransitionPayload(BaseModel):
         if isinstance(v, str) and v in LANE_ALIASES:
             return LANE_ALIASES[v].value
         return v
+
+    @field_validator("actor", mode="after")
+    @classmethod
+    def _validate_actor(cls, v):
+        """Ensure actor is a non-empty string or non-empty dict."""
+        if isinstance(v, str):
+            if not v.strip():
+                raise ValueError("actor string must be non-empty")
+            return v
+        if isinstance(v, dict):
+            if not v:
+                raise ValueError("actor dict must be non-empty")
+            return v
+        raise ValueError("actor must be a string or dict")
+
+    @property
+    def actor_label(self) -> str:
+        """Canonical string form of ``actor`` for reducers, logs, and display.
+
+        Returns the string itself if ``actor`` is a string. For dict actors,
+        prefers ``profile`` then ``role`` then ``display_name`` then ``actor_id``
+        then the first non-empty string value, falling back to ``"unknown"``.
+
+        Intentionally a plain ``@property`` rather than ``@computed_field`` so
+        that the derived value is not round-tripped through ``model_dump()``
+        (which would conflict with ``extra="forbid"`` on reload).
+        """
+        if isinstance(self.actor, str):
+            return self.actor
+        for key in ("profile", "role", "display_name", "actor_id"):
+            value = self.actor.get(key)
+            if isinstance(value, str) and value:
+                return value
+        for value in self.actor.values():
+            if isinstance(value, str) and value:
+                return value
+        return "unknown"
 
     @model_validator(mode="after")
     def _check_business_rules(self) -> "StatusTransitionPayload":
@@ -530,19 +578,34 @@ def reduce_status_events(events: Sequence[Event]) -> ReducedStatus:
             # Check from_lane matches state at group start
             expected_lane = snapped.current_lane if snapped else None
             if payload.from_lane != expected_lane:
-                anomalies.append(
-                    TransitionAnomaly(
-                        event_id=event.event_id,
-                        wp_id=wp_id,
-                        from_lane=payload.from_lane,
-                        to_lane=payload.to_lane,
-                        reason=(
-                            f"from_lane mismatch: expected {expected_lane}, "
-                            f"got {payload.from_lane}"
-                        ),
+                if payload.force:
+                    # Historical/bootstrap migration events (e.g. frontmatter-to-JSONL
+                    # backfill) legitimately carry mid-lifecycle from_lane values.
+                    # StatusTransitionPayload requires a non-empty reason when
+                    # force=true (see validator below), which provides the audit trail.
+                    logger.warning(
+                        "forced transition bypassing from_lane mismatch: "
+                        "wp=%s event=%s expected=%s got=%s reason=%s",
+                        wp_id,
+                        event.event_id,
+                        expected_lane,
+                        payload.from_lane,
+                        payload.reason,
                     )
-                )
-                continue
+                else:
+                    anomalies.append(
+                        TransitionAnomaly(
+                            event_id=event.event_id,
+                            wp_id=wp_id,
+                            from_lane=payload.from_lane,
+                            to_lane=payload.to_lane,
+                            reason=(
+                                f"from_lane mismatch: expected {expected_lane}, "
+                                f"got {payload.from_lane}"
+                            ),
+                        )
+                    )
+                    continue
 
             # Validate transition
             validation = validate_transition(payload)

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -1229,3 +1229,141 @@ class TestReduceStatusEvents:
         ]
         result = reduce_status_events(events)
         assert result.last_processed_event_id == "01HV0000000000000000000002"
+
+
+# ---------------------------------------------------------------------------
+# Section 6: Force=True bypasses from_lane mismatch (spec-kitty-saas#86)
+# ---------------------------------------------------------------------------
+
+
+class TestReduceStatusEventsForceBypass:
+    """Force=True must bypass the from_lane-mismatch check.
+
+    Historical/bootstrap migration events carry mid-lifecycle from_lane with
+    force=true and a non-empty reason (enforced by StatusTransitionPayload).
+    The reducer treats these as valid state-establishing transitions.
+    """
+
+    def test_force_true_bypasses_from_lane_mismatch(self) -> None:
+        """Standalone forced event with mid-lifecycle from_lane emits no anomaly."""
+        base_t = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        # No prior state for WP01. Forced event claims from_lane=IN_PROGRESS.
+        e = _make_event(
+            "01HV0000000000000000000F01",
+            "WP01",
+            Lane.IN_PROGRESS,
+            Lane.FOR_REVIEW,
+            1,
+            timestamp=base_t,
+            force=True,
+            reason="historical_frontmatter_to_jsonl:v1",
+        )
+        result = reduce_status_events([e])
+        assert result.anomalies == []
+        assert result.wp_states["WP01"].current_lane == Lane.FOR_REVIEW
+
+    def test_force_false_still_flags_mismatch(self) -> None:
+        """Same scenario without force still emits a from_lane_mismatch anomaly."""
+        base_t = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        e = _make_event(
+            "01HV0000000000000000000F02",
+            "WP01",
+            Lane.IN_PROGRESS,
+            Lane.FOR_REVIEW,
+            1,
+            timestamp=base_t,
+        )
+        result = reduce_status_events([e])
+        assert len(result.anomalies) == 1
+        assert "from_lane mismatch" in result.anomalies[0].reason
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            "historical migration",
+            "canonical bootstrap",
+            "historical_frontmatter_to_jsonl:v1",
+            "bootstrapped from legacy state",
+            "bootstrap from frontmatter lane in_progress before move-task transition",
+        ],
+    )
+    def test_force_true_accepts_known_bootstrap_reasons(self, reason: str) -> None:
+        """All five bootstrap reasons observed in the field project cleanly."""
+        base_t = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        e = _make_event(
+            "01HV0000000000000000000F03",
+            "WP01",
+            Lane.PLANNED,
+            Lane.IN_PROGRESS,
+            1,
+            timestamp=base_t,
+            force=True,
+            reason=reason,
+        )
+        result = reduce_status_events([e])
+        assert result.anomalies == []
+
+
+# ---------------------------------------------------------------------------
+# Section 7: Structured actor support (spec-kitty-saas#86 R3)
+# ---------------------------------------------------------------------------
+
+
+class TestStatusTransitionPayloadActor:
+    """StatusTransitionPayload.actor accepts string or dict with actor_label fallback."""
+
+    def test_actor_accepts_string(self) -> None:
+        p = StatusTransitionPayload(
+            mission_slug="m",
+            wp_id="WP01",
+            from_lane=None,
+            to_lane=Lane.PLANNED,
+            actor="claude",
+            execution_mode=ExecutionMode.WORKTREE,
+        )
+        assert p.actor == "claude"
+        assert p.actor_label == "claude"
+
+    def test_actor_accepts_dict_and_resolves_label(self) -> None:
+        p = StatusTransitionPayload(
+            mission_slug="m",
+            wp_id="WP01",
+            from_lane=None,
+            to_lane=Lane.PLANNED,
+            actor={"role": "implementer", "profile": "implementer", "tool": "claude-code"},
+            execution_mode=ExecutionMode.WORKTREE,
+        )
+        assert p.actor_label == "implementer"
+
+    def test_actor_label_prefers_profile_over_role(self) -> None:
+        p = StatusTransitionPayload(
+            mission_slug="m",
+            wp_id="WP01",
+            from_lane=None,
+            to_lane=Lane.PLANNED,
+            actor={"role": "a", "profile": "b"},
+            execution_mode=ExecutionMode.WORKTREE,
+        )
+        assert p.actor_label == "b"
+
+    def test_actor_label_fallback_to_first_string_value(self) -> None:
+        p = StatusTransitionPayload(
+            mission_slug="m",
+            wp_id="WP01",
+            from_lane=None,
+            to_lane=Lane.PLANNED,
+            actor={"tool": "cli", "model": "claude-sonnet"},
+            execution_mode=ExecutionMode.WORKTREE,
+        )
+        assert p.actor_label in {"cli", "claude-sonnet"}
+
+    def test_empty_dict_actor_rejected(self) -> None:
+        with pytest.raises(pydantic.ValidationError):
+            StatusTransitionPayload(
+                mission_slug="m",
+                wp_id="WP01",
+                from_lane=None,
+                to_lane=Lane.PLANNED,
+                actor={},
+                execution_mode=ExecutionMode.WORKTREE,
+            )


### PR DESCRIPTION
## Summary
- let reduce_status_events bypass from_lane mismatch when force=true and a reason is present
- accept structured actor payloads with actor_label normalization
- regenerate schemas and add reducer/actor coverage tests

## Verification
- uv run pytest tests/unit/test_status.py

Part of Priivacy-ai/spec-kitty-saas#86