### PR TITLE
feat: add mission analytics event contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to spec-kitty-events will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.3.0 — Mission Analytics Contracts (2026-04-22)
+
+### Added
+
+- Added canonical analytics payload contracts:
+  `TokenUsageRecordedPayload` and `DiffSummaryRecordedPayload`.
+- Added `TOKEN_USAGE_RECORDED`, `DIFF_SUMMARY_RECORDED`, and
+  `ANALYTICS_EVENT_TYPES` exports.
+- Added committed JSON schemas and conformance fixtures for the analytics
+  payload family.
+
+### Why
+
+- `spec-kitty` and `spec-kitty-saas` now have a canonical contract surface for
+  Mission Scorecard token/cost accounting and diff-summary reporting.
+- Downstream consumers no longer need repo-local telemetry schemas for these
+  analytics records.
+
 ## 2.9.0 — Approved Lane Contract (2026-04-04)
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-events"
-version = "3.2.0"
+version = "3.3.0"
 description = "Event log library with Lamport clocks and systematic error tracking"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -80,6 +80,8 @@ spec_kitty_events = [
     "conformance/fixtures/profile_invocation/invalid/*.json",
     "conformance/fixtures/retrospective/valid/*.json",
     "conformance/fixtures/retrospective/invalid/*.json",
+    "conformance/fixtures/analytics/valid/*.json",
+    "conformance/fixtures/analytics/invalid/*.json",
     "conformance/fixtures/replay/*.jsonl",
     "conformance/fixtures/replay/*.json",
 ]

--- a/src/spec_kitty_events/__init__.py
+++ b/src/spec_kitty_events/__init__.py
@@ -8,7 +8,7 @@ This release publishes the fail-closed cutover surface for:
 - authoritative artifact-driven compatibility gating via ``spec_kitty_events.cutover``
 """
 
-__version__ = "3.2.0"
+__version__ = "3.3.0"
 
 from spec_kitty_events.cutover import (
     CUTOVER_ARTIFACT,
@@ -225,6 +225,15 @@ from spec_kitty_events.mission_next import (
     MissionNextAnomaly,
     ReducedMissionRunState,
     reduce_mission_next_events,
+)
+
+# Analytics event contracts
+from spec_kitty_events.analytics import (
+    TOKEN_USAGE_RECORDED,
+    DIFF_SUMMARY_RECORDED,
+    ANALYTICS_EVENT_TYPES,
+    TokenUsageRecordedPayload,
+    DiffSummaryRecordedPayload,
 )
 
 # Dossier event contracts (v2.4.0)

--- a/src/spec_kitty_events/analytics.py
+++ b/src/spec_kitty_events/analytics.py
@@ -1,0 +1,75 @@
+"""Mission analytics event contracts.
+
+Canonical analytics payloads used to build mission scorecards without
+repo-local schema forks.
+"""
+
+from __future__ import annotations
+
+from typing import FrozenSet, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from spec_kitty_events.mission_next import RuntimeActorIdentity
+
+TOKEN_USAGE_RECORDED: str = "TokenUsageRecorded"
+DIFF_SUMMARY_RECORDED: str = "DiffSummaryRecorded"
+
+ANALYTICS_EVENT_TYPES: FrozenSet[str] = frozenset({
+    TOKEN_USAGE_RECORDED,
+    DIFF_SUMMARY_RECORDED,
+})
+
+
+class TokenUsageRecordedPayload(BaseModel):
+    """Canonical token and estimated-cost accounting payload."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    mission_id: str = Field(..., min_length=1, description="Canonical mission identifier")
+    run_id: Optional[str] = Field(None, min_length=1, description="Mission run identifier when available")
+    step_id: Optional[str] = Field(None, min_length=1, description="Mission step identifier when available")
+    wp_id: Optional[str] = Field(None, min_length=1, description="Work-package identifier when available")
+    phase_name: Optional[str] = Field(None, min_length=1, description="Mission phase name when known")
+    actor: Optional[RuntimeActorIdentity] = Field(
+        None,
+        description="Runtime actor identity when available",
+    )
+    provider: Optional[str] = Field(None, min_length=1, description="LLM provider when available")
+    model: Optional[str] = Field(None, min_length=1, description="LLM model when available")
+    input_tokens: int = Field(..., ge=0, description="Prompt/input token count")
+    output_tokens: int = Field(..., ge=0, description="Completion/output token count")
+    total_tokens: int = Field(..., ge=0, description="Total token count")
+    estimated_cost_usd: float = Field(
+        ...,
+        ge=0,
+        description="Estimated USD cost for the usage record",
+    )
+    source: str = Field(..., min_length=1, description="Usage data source identifier")
+
+    @model_validator(mode="after")
+    def _validate_totals(self) -> "TokenUsageRecordedPayload":
+        expected_total = self.input_tokens + self.output_tokens
+        if self.total_tokens != expected_total:
+            raise ValueError(
+                "total_tokens must equal input_tokens + output_tokens"
+            )
+        return self
+
+
+class DiffSummaryRecordedPayload(BaseModel):
+    """Canonical git diff summary payload."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    mission_id: str = Field(..., min_length=1, description="Canonical mission identifier")
+    run_id: Optional[str] = Field(None, min_length=1, description="Mission run identifier when available")
+    step_id: Optional[str] = Field(None, min_length=1, description="Mission step identifier when available")
+    wp_id: Optional[str] = Field(None, min_length=1, description="Work-package identifier when available")
+    phase_name: Optional[str] = Field(None, min_length=1, description="Mission phase name when known")
+    base_ref: str = Field(..., min_length=1, description="Diff base git ref or commit")
+    head_ref: str = Field(..., min_length=1, description="Diff head git ref or commit")
+    files_changed: int = Field(..., ge=0, description="Count of files changed in the diff")
+    lines_added: int = Field(..., ge=0, description="Lines added in the diff")
+    lines_deleted: int = Field(..., ge=0, description="Lines deleted in the diff")
+    source: str = Field(..., min_length=1, description="Diff summary source identifier")

--- a/src/spec_kitty_events/conformance/fixtures/analytics/invalid/diff_summary_recorded_missing_base_ref.json
+++ b/src/spec_kitty_events/conformance/fixtures/analytics/invalid/diff_summary_recorded_missing_base_ref.json
@@ -1,0 +1,9 @@
+{
+  "mission_id": "01JTJ8M3Z3ZV4A6J3B1Q4JQ8RM",
+  "run_id": "run-analytics-001",
+  "head_ref": "HEAD",
+  "files_changed": 7,
+  "lines_added": 184,
+  "lines_deleted": 42,
+  "source": "git-numstat"
+}

--- a/src/spec_kitty_events/conformance/fixtures/analytics/invalid/token_usage_recorded_invalid_total.json
+++ b/src/spec_kitty_events/conformance/fixtures/analytics/invalid/token_usage_recorded_invalid_total.json
@@ -1,0 +1,11 @@
+{
+  "mission_id": "01JTJ8M3Z3ZV4A6J3B1Q4JQ8RM",
+  "run_id": "run-analytics-001",
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "input_tokens": 1200,
+  "output_tokens": 300,
+  "total_tokens": 1499,
+  "estimated_cost_usd": 0.036,
+  "source": "runtime-usage"
+}

--- a/src/spec_kitty_events/conformance/fixtures/analytics/valid/diff_summary_recorded_valid.json
+++ b/src/spec_kitty_events/conformance/fixtures/analytics/valid/diff_summary_recorded_valid.json
@@ -1,0 +1,13 @@
+{
+  "mission_id": "01JTJ8M3Z3ZV4A6J3B1Q4JQ8RM",
+  "run_id": "run-analytics-001",
+  "step_id": "review",
+  "wp_id": "WP03",
+  "phase_name": "review",
+  "base_ref": "origin/main",
+  "head_ref": "HEAD",
+  "files_changed": 7,
+  "lines_added": 184,
+  "lines_deleted": 42,
+  "source": "git-numstat"
+}

--- a/src/spec_kitty_events/conformance/fixtures/analytics/valid/token_usage_recorded_valid.json
+++ b/src/spec_kitty_events/conformance/fixtures/analytics/valid/token_usage_recorded_valid.json
@@ -1,0 +1,22 @@
+{
+  "mission_id": "01JTJ8M3Z3ZV4A6J3B1Q4JQ8RM",
+  "run_id": "run-analytics-001",
+  "step_id": "implement",
+  "wp_id": "WP03",
+  "phase_name": "implementation",
+  "actor": {
+    "actor_id": "codex",
+    "actor_type": "llm",
+    "display_name": "Codex",
+    "provider": "openai",
+    "model": "gpt-5.4",
+    "tool": "codex"
+  },
+  "provider": "openai",
+  "model": "gpt-5.4",
+  "input_tokens": 1200,
+  "output_tokens": 300,
+  "total_tokens": 1500,
+  "estimated_cost_usd": 0.036,
+  "source": "runtime-usage"
+}

--- a/src/spec_kitty_events/conformance/fixtures/manifest.json
+++ b/src/spec_kitty_events/conformance/fixtures/manifest.json
@@ -1161,6 +1161,38 @@
       "min_version": "3.1.0"
     },
     {
+      "id": "analytics-token-usage-recorded-valid",
+      "path": "analytics/valid/token_usage_recorded_valid.json",
+      "expected_result": "valid",
+      "event_type": "TokenUsageRecorded",
+      "notes": "Valid TokenUsageRecordedPayload with runtime actor and cost accounting",
+      "min_version": "3.3.0"
+    },
+    {
+      "id": "analytics-diff-summary-recorded-valid",
+      "path": "analytics/valid/diff_summary_recorded_valid.json",
+      "expected_result": "valid",
+      "event_type": "DiffSummaryRecorded",
+      "notes": "Valid DiffSummaryRecordedPayload with mission, run, and work-package scope",
+      "min_version": "3.3.0"
+    },
+    {
+      "id": "analytics-token-usage-recorded-invalid-total",
+      "path": "analytics/invalid/token_usage_recorded_invalid_total.json",
+      "expected_result": "invalid",
+      "event_type": "TokenUsageRecorded",
+      "notes": "total_tokens must equal input_tokens + output_tokens",
+      "min_version": "3.3.0"
+    },
+    {
+      "id": "analytics-diff-summary-recorded-invalid-missing-base-ref",
+      "path": "analytics/invalid/diff_summary_recorded_missing_base_ref.json",
+      "expected_result": "invalid",
+      "event_type": "DiffSummaryRecorded",
+      "notes": "Missing required base_ref field",
+      "min_version": "3.3.0"
+    },
+    {
       "id": "profile-invocation-started-valid-full",
       "path": "profile_invocation/valid/profile_invocation_started_full.json",
       "expected_result": "valid",

--- a/src/spec_kitty_events/conformance/loader.py
+++ b/src/spec_kitty_events/conformance/loader.py
@@ -17,6 +17,7 @@ _MANIFEST_PATH = _FIXTURES_DIR / "manifest.json"
 _VALID_CATEGORIES = frozenset({
     "events", "lane_mapping", "edge_cases",
     "collaboration", "glossary", "mission_next",
+    "analytics",
     "dossier", "mission_audit", "decisionpoint",
     "connector", "sync",
     "profile_invocation", "retrospective",  # 3.1.0
@@ -51,7 +52,7 @@ def load_fixtures(category: str) -> List[FixtureCase]:
     Args:
         category: One of ``"events"``, ``"lane_mapping"``, ``"edge_cases"``,
             ``"collaboration"``, ``"glossary"``, ``"mission_next"``, ``"dossier"``,
-            ``"mission_audit"``, ``"decisionpoint"``, ``"connector"``, ``"sync"``,
+            ``"analytics"``, ``"mission_audit"``, ``"decisionpoint"``, ``"connector"``, ``"sync"``,
             ``"profile_invocation"``, or ``"retrospective"``.
 
     Returns:

--- a/src/spec_kitty_events/conformance/validators.py
+++ b/src/spec_kitty_events/conformance/validators.py
@@ -62,6 +62,10 @@ from spec_kitty_events.mission_next import (
     DecisionInputAnsweredPayload,
     MissionRunCompletedPayload,
 )
+from spec_kitty_events.analytics import (
+    TokenUsageRecordedPayload,
+    DiffSummaryRecordedPayload,
+)
 from spec_kitty_events.dossier import (
     MissionDossierArtifactIndexedPayload,
     MissionDossierArtifactMissingPayload,
@@ -181,6 +185,9 @@ _EVENT_TYPE_TO_MODEL: Dict[str, Type[Any]] = {
     "DecisionInputRequested": DecisionInputRequestedPayload,
     "DecisionInputAnswered": DecisionInputAnsweredPayload,
     "MissionRunCompleted": MissionRunCompletedPayload,
+    # Analytics contracts (3.3.0)
+    "TokenUsageRecorded": TokenUsageRecordedPayload,
+    "DiffSummaryRecorded": DiffSummaryRecordedPayload,
     # Dossier event contracts
     "MissionDossierArtifactIndexed": MissionDossierArtifactIndexedPayload,
     "MissionDossierArtifactMissing": MissionDossierArtifactMissingPayload,
@@ -261,6 +268,9 @@ _EVENT_TYPE_TO_SCHEMA: Dict[str, str] = {
     "DecisionInputRequested": "decision_input_requested_payload",
     "DecisionInputAnswered": "decision_input_answered_payload",
     "MissionRunCompleted": "mission_run_completed_payload",
+    # Analytics contracts (3.3.0)
+    "TokenUsageRecorded": "token_usage_recorded_payload",
+    "DiffSummaryRecorded": "diff_summary_recorded_payload",
     # Dossier event contracts
     "MissionDossierArtifactIndexed": "mission_dossier_artifact_indexed_payload",
     "MissionDossierArtifactMissing": "mission_dossier_artifact_missing_payload",

--- a/src/spec_kitty_events/schemas/diff_summary_recorded_payload.schema.json
+++ b/src/spec_kitty_events/schemas/diff_summary_recorded_payload.schema.json
@@ -1,0 +1,117 @@
+{
+  "$id": "spec-kitty-events/diff_summary_recorded_payload",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Canonical git diff summary payload.",
+  "properties": {
+    "base_ref": {
+      "description": "Diff base git ref or commit",
+      "minLength": 1,
+      "title": "Base Ref",
+      "type": "string"
+    },
+    "files_changed": {
+      "description": "Count of files changed in the diff",
+      "minimum": 0,
+      "title": "Files Changed",
+      "type": "integer"
+    },
+    "head_ref": {
+      "description": "Diff head git ref or commit",
+      "minLength": 1,
+      "title": "Head Ref",
+      "type": "string"
+    },
+    "lines_added": {
+      "description": "Lines added in the diff",
+      "minimum": 0,
+      "title": "Lines Added",
+      "type": "integer"
+    },
+    "lines_deleted": {
+      "description": "Lines deleted in the diff",
+      "minimum": 0,
+      "title": "Lines Deleted",
+      "type": "integer"
+    },
+    "mission_id": {
+      "description": "Canonical mission identifier",
+      "minLength": 1,
+      "title": "Mission Id",
+      "type": "string"
+    },
+    "phase_name": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Mission phase name when known",
+      "title": "Phase Name"
+    },
+    "run_id": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Mission run identifier when available",
+      "title": "Run Id"
+    },
+    "source": {
+      "description": "Diff summary source identifier",
+      "minLength": 1,
+      "title": "Source",
+      "type": "string"
+    },
+    "step_id": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Mission step identifier when available",
+      "title": "Step Id"
+    },
+    "wp_id": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Work-package identifier when available",
+      "title": "Wp Id"
+    }
+  },
+  "required": [
+    "mission_id",
+    "base_ref",
+    "head_ref",
+    "files_changed",
+    "lines_added",
+    "lines_deleted",
+    "source"
+  ],
+  "title": "DiffSummaryRecordedPayload",
+  "type": "object"
+}

--- a/src/spec_kitty_events/schemas/generate.py
+++ b/src/spec_kitty_events/schemas/generate.py
@@ -71,6 +71,10 @@ from spec_kitty_events.mission_next import (
     DecisionInputAnsweredPayload,
     MissionRunCompletedPayload,
 )
+from spec_kitty_events.analytics import (
+    TokenUsageRecordedPayload,
+    DiffSummaryRecordedPayload,
+)
 from spec_kitty_events.dossier import (
     ArtifactIdentity,
     ContentHashRef,
@@ -174,6 +178,9 @@ PYDANTIC_MODELS: List[tuple[str, Type[BaseModel]]] = [
     ("decision_input_requested_payload", DecisionInputRequestedPayload),
     ("decision_input_answered_payload", DecisionInputAnsweredPayload),
     ("mission_run_completed_payload", MissionRunCompletedPayload),
+    # Analytics models (3.3.0)
+    ("token_usage_recorded_payload", TokenUsageRecordedPayload),
+    ("diff_summary_recorded_payload", DiffSummaryRecordedPayload),
     # Dossier event contract models
     ("artifact_identity", ArtifactIdentity),
     ("content_hash_ref", ContentHashRef),

--- a/src/spec_kitty_events/schemas/token_usage_recorded_payload.schema.json
+++ b/src/spec_kitty_events/schemas/token_usage_recorded_payload.schema.json
@@ -1,0 +1,220 @@
+{
+  "$defs": {
+    "RuntimeActorIdentity": {
+      "description": "Identity of a runtime actor (human, LLM, or service).",
+      "properties": {
+        "actor_id": {
+          "description": "Unique actor identifier",
+          "minLength": 1,
+          "title": "Actor Id",
+          "type": "string"
+        },
+        "actor_type": {
+          "description": "Actor category",
+          "pattern": "^(human|llm|service)$",
+          "title": "Actor Type",
+          "type": "string"
+        },
+        "display_name": {
+          "default": "",
+          "description": "Human-readable display name",
+          "title": "Display Name",
+          "type": "string"
+        },
+        "model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Model identifier (e.g., 'claude-opus-4-6')",
+          "title": "Model"
+        },
+        "provider": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Provider (e.g., 'anthropic', 'openai')",
+          "title": "Provider"
+        },
+        "tool": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Tool identifier",
+          "title": "Tool"
+        }
+      },
+      "required": [
+        "actor_id",
+        "actor_type"
+      ],
+      "title": "RuntimeActorIdentity",
+      "type": "object"
+    }
+  },
+  "$id": "spec-kitty-events/token_usage_recorded_payload",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Canonical token and estimated-cost accounting payload.",
+  "properties": {
+    "actor": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/RuntimeActorIdentity"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Runtime actor identity when available"
+    },
+    "estimated_cost_usd": {
+      "description": "Estimated USD cost for the usage record",
+      "minimum": 0,
+      "title": "Estimated Cost Usd",
+      "type": "number"
+    },
+    "input_tokens": {
+      "description": "Prompt/input token count",
+      "minimum": 0,
+      "title": "Input Tokens",
+      "type": "integer"
+    },
+    "mission_id": {
+      "description": "Canonical mission identifier",
+      "minLength": 1,
+      "title": "Mission Id",
+      "type": "string"
+    },
+    "model": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "LLM model when available",
+      "title": "Model"
+    },
+    "output_tokens": {
+      "description": "Completion/output token count",
+      "minimum": 0,
+      "title": "Output Tokens",
+      "type": "integer"
+    },
+    "phase_name": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Mission phase name when known",
+      "title": "Phase Name"
+    },
+    "provider": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "LLM provider when available",
+      "title": "Provider"
+    },
+    "run_id": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Mission run identifier when available",
+      "title": "Run Id"
+    },
+    "source": {
+      "description": "Usage data source identifier",
+      "minLength": 1,
+      "title": "Source",
+      "type": "string"
+    },
+    "step_id": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Mission step identifier when available",
+      "title": "Step Id"
+    },
+    "total_tokens": {
+      "description": "Total token count",
+      "minimum": 0,
+      "title": "Total Tokens",
+      "type": "integer"
+    },
+    "wp_id": {
+      "anyOf": [
+        {
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Work-package identifier when available",
+      "title": "Wp Id"
+    }
+  },
+  "required": [
+    "mission_id",
+    "input_tokens",
+    "output_tokens",
+    "total_tokens",
+    "estimated_cost_usd",
+    "source"
+  ],
+  "title": "TokenUsageRecordedPayload",
+  "type": "object"
+}

--- a/src/spec_kitty_events/status.py
+++ b/src/spec_kitty_events/status.py
@@ -248,7 +248,7 @@ class StatusTransitionPayload(BaseModel):
 
     @field_validator("actor", mode="after")
     @classmethod
-    def _validate_actor(cls, v):
+    def _validate_actor(cls, v: Union[str, Dict[str, Any]]) -> Union[str, Dict[str, Any]]:
         """Ensure actor is a non-empty string or non-empty dict."""
         if isinstance(v, str):
             if not v.strip():

--- a/tests/test_analytics_conformance.py
+++ b/tests/test_analytics_conformance.py
@@ -1,0 +1,62 @@
+"""Conformance tests for analytics event contracts."""
+from __future__ import annotations
+
+import pytest
+
+from spec_kitty_events.analytics import (
+    DiffSummaryRecordedPayload,
+    TokenUsageRecordedPayload,
+)
+from spec_kitty_events.conformance import load_fixtures, validate_event
+
+_ANALYTICS_CASES = load_fixtures("analytics")
+_VALID_CASES = [c for c in _ANALYTICS_CASES if c.expected_valid]
+_INVALID_CASES = [c for c in _ANALYTICS_CASES if not c.expected_valid]
+
+
+@pytest.mark.parametrize("case", _VALID_CASES, ids=[c.id for c in _VALID_CASES])
+def test_valid_analytics_fixture_passes_conformance(case: object) -> None:
+    from spec_kitty_events.conformance.loader import FixtureCase
+
+    assert isinstance(case, FixtureCase)
+    result = validate_event(case.payload, case.event_type, strict=True)
+    assert result.valid, (
+        f"Fixture {case.id} should be valid but got violations:\n"
+        f"Model: {result.model_violations}\n"
+        f"Schema: {result.schema_violations}"
+    )
+
+
+@pytest.mark.parametrize("case", _INVALID_CASES, ids=[c.id for c in _INVALID_CASES])
+def test_invalid_analytics_fixture_fails_conformance(case: object) -> None:
+    from spec_kitty_events.conformance.loader import FixtureCase
+
+    assert isinstance(case, FixtureCase)
+    result = validate_event(case.payload, case.event_type, strict=True)
+    assert not result.valid, (
+        f"Fixture {case.id} should be invalid but passed validation"
+    )
+    assert len(result.model_violations) >= 1, (
+        f"Fixture {case.id} is invalid but no model_violations were reported"
+    )
+
+
+def test_analytics_fixture_count() -> None:
+    assert len(_ANALYTICS_CASES) == 4
+
+
+@pytest.mark.parametrize(
+    "model_class,schema_name",
+    [
+        (TokenUsageRecordedPayload, "token_usage_recorded_payload"),
+        (DiffSummaryRecordedPayload, "diff_summary_recorded_payload"),
+    ],
+    ids=["token_usage_recorded", "diff_summary_recorded"],
+)
+def test_analytics_schema_drift(model_class: type, schema_name: str) -> None:
+    from spec_kitty_events.schemas import load_schema
+    from spec_kitty_events.schemas.generate import generate_schema
+
+    generated = generate_schema(schema_name, model_class)
+    committed = load_schema(schema_name)
+    assert generated == committed

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -8,9 +8,8 @@ from spec_kitty_events.schemas import list_schemas, load_schema, schema_path
 
 
 def test_list_schemas_returns_all_names() -> None:
-    """Test that list_schemas returns all 82 schema names."""
+    """Test that list_schemas returns the committed schema set."""
     names = list_schemas()
-    assert len(names) == 82
     expected = [
         "artifact_identity",
         "auth_principal_binding",
@@ -30,6 +29,7 @@ def test_list_schemas_returns_all_names() -> None:
         "decision_point_opened_payload",
         "decision_point_overridden_payload",
         "decision_point_resolved_payload",
+        "diff_summary_recorded_payload",
         "drive_intent_set_payload",
         "event",
         "external_reference_linked_payload",
@@ -90,11 +90,13 @@ def test_list_schemas_returns_all_names() -> None:
         "sync_replay_completed_payload",
         "sync_retry_scheduled_payload",
         "term_candidate_observed_payload",
+        "token_usage_recorded_payload",
         "user_connected_payload",
         "user_connection_status",
         "user_disconnected_payload",
         "warning_acknowledged_payload",
     ]
+    assert len(names) == len(expected)
     assert names == expected
 
 


### PR DESCRIPTION
## Summary
- add canonical analytics contracts for token usage and diff summaries
- publish schemas and conformance fixtures for the new analytics event family
- add analytics conformance coverage for the new payload models

Closes #12

## Verification
- .venv/bin/python -m pytest tests/test_analytics_conformance.py src/spec_kitty_events/conformance/test_pyargs_entrypoint.py -q