### PR TITLE
ci: add cross-repo-harness-tests workflow + README for identity-boundary CI gate (3/3)

### DIFF
--- a/.github/workflows/cross-repo-harness-tests.yml
+++ b/.github/workflows/cross-repo-harness-tests.yml
@@ -1,0 +1,81 @@
+name: Cross-Repo Harness Tests (identity-boundary)
+
+# This workflow is the spec-kitty-events side of the three-repo
+# identity-boundary canary CI gate. On every PR against `main` (and on
+# push to main), it clones spec-kitty-end-to-end-testing at a pinned
+# commit SHA and runs the harness's identity-boundary unit tests with
+# THIS PR's events source code installed as editable into the e2e
+# environment. That way an envelope-shape regression in events surfaces
+# as a red `harness-unit-tests` job at PR time — before the SaaS strict
+# gate sees it in production.
+#
+# Tracking: https://github.com/Priivacy-ai/spec-kitty/issues/1247
+# Mission:  spec-kitty kitty-specs/identity-boundary-canary-ci-gate-01KS4XWV/
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: harness-unit-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # Pinned head-of-spec-kitty-end-to-end-testing main at the time the
+  # canary-gate mission shipped. Bump this SHA in tandem with this
+  # README's "Updating the pinned e2e SHA" procedure when intentional
+  # contract changes ship in e2e.
+  E2E_PINNED_SHA: '03e4d3c04fcdf641cd564badfbc87bb19a2a0982'
+
+jobs:
+  harness-unit-tests:
+    name: harness-unit-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout this repo (events)
+        uses: actions/checkout@v6
+        with:
+          path: events
+
+      - name: Checkout spec-kitty-end-to-end-testing at pinned SHA
+        uses: actions/checkout@v6
+        with:
+          repository: Priivacy-ai/spec-kitty-end-to-end-testing
+          ref: ${{ env.E2E_PINNED_SHA }}
+          path: e2e
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Install e2e harness
+        working-directory: e2e
+        run: |
+          uv sync
+
+      - name: Install THIS PR's events source as editable into the e2e env
+        # This is the key invariant: the harness must exercise the PR's
+        # events code, not whatever e2e's lockfile pinned. Otherwise an
+        # envelope-shape regression introduced in this PR would not
+        # surface here.
+        working-directory: e2e
+        run: |
+          uv pip install -e ../events
+
+      - name: Run identity-boundary harness unit tests
+        working-directory: e2e
+        run: |
+          uv run pytest \
+            tests/unit/identity_boundary/ \
+            tests/identity_boundary/unit/ \
+            -v --tb=short

--- a/README.md
+++ b/README.md
@@ -162,3 +162,82 @@ This package now publishes the TeamSpace migration release as package `5.0.0`.
 ## License
 
 All rights reserved. This repository is owned by Priivacy AI.
+
+## Identity-boundary canary CI gate
+
+This repo participates in a three-repo CI gate that pins the
+identity-boundary canary protocol (closed
+[`spec-kitty-end-to-end-testing#41`](https://github.com/Priivacy-ai/spec-kitty-end-to-end-testing/issues/41))
+as a required check on every PR.
+
+**Workflow**: [`.github/workflows/cross-repo-harness-tests.yml`](.github/workflows/cross-repo-harness-tests.yml)
+**Job name (register this as the required check)**: `harness-unit-tests`
+
+### What it runs
+
+On every PR against `main`, the workflow:
+
+1. Checks out this repo at the PR commit.
+2. Checks out
+   [`Priivacy-ai/spec-kitty-end-to-end-testing`](https://github.com/Priivacy-ai/spec-kitty-end-to-end-testing)
+   at the pinned commit SHA (see `E2E_PINNED_SHA` in the workflow file).
+3. Installs the e2e harness via `uv sync`.
+4. **Installs this repo's events source as editable** into the e2e env
+   via `uv pip install -e ../events`. This is the key invariant — the
+   harness must exercise the PR's events code, not whatever e2e's
+   lockfile pinned, so an envelope-shape regression introduced by the
+   PR surfaces here.
+5. Runs `uv run pytest tests/unit/identity_boundary/ tests/identity_boundary/unit/`.
+
+If any test fails, the PR is blocked from merging (once the required
+check is enabled — see admin action below).
+
+### Pinned e2e SHA
+
+The workflow pins `Priivacy-ai/spec-kitty-end-to-end-testing` to a
+specific commit SHA via the `E2E_PINNED_SHA` env var at the top of
+`.github/workflows/cross-repo-harness-tests.yml`. This is intentional:
+it prevents drift where an unrelated change in e2e's main accidentally
+breaks (or unintentionally papers over) this repo's gate.
+
+**Current pin**: `03e4d3c04fcdf641cd564badfbc87bb19a2a0982`
+
+### Updating the pinned e2e SHA
+
+When an intentional contract change ships in e2e:
+
+1. Land the contract change in
+   [`spec-kitty-end-to-end-testing`](https://github.com/Priivacy-ai/spec-kitty-end-to-end-testing)
+   first.
+2. Open a PR in this repo that updates `E2E_PINNED_SHA` in
+   `.github/workflows/cross-repo-harness-tests.yml` and the "Current
+   pin" line in this README to the new SHA.
+3. Confirm the gate goes green on the bump PR before merging.
+
+If the e2e change is itself a breaking events-envelope change, this
+repo's PR introducing that change should ship together with the SHA
+bump in a single PR.
+
+### Local reproduction
+
+To exercise the gate locally, in a checkout of
+spec-kitty-end-to-end-testing at the pinned SHA:
+
+```bash
+cd /path/to/spec-kitty-end-to-end-testing
+uv sync
+uv pip install -e /path/to/spec-kitty-events
+uv run pytest tests/unit/identity_boundary/ tests/identity_boundary/unit/ -v
+```
+
+### Sibling-repo gates
+
+| Repo | Workflow | Job |
+|---|---|---|
+| `spec-kitty` | `.github/workflows/canary-gate.yml` | `drift-detector` |
+| `spec-kitty-saas` | `.github/workflows/canary-gate.yml` | `canary-gate` |
+
+### Tracking
+
+- Mission spec: [`Priivacy-ai/spec-kitty kitty-specs/identity-boundary-canary-ci-gate-01KS4XWV/`](https://github.com/Priivacy-ai/spec-kitty/tree/main/kitty-specs/identity-boundary-canary-ci-gate-01KS4XWV)
+- Tracker: [`Priivacy-ai/spec-kitty#1247`](https://github.com/Priivacy-ai/spec-kitty/issues/1247)


### PR DESCRIPTION
## Summary

Adds the spec-kitty-events side of a three-repo CI gate that pins the
identity-boundary canary protocol (closed
[`spec-kitty-end-to-end-testing#41`](https://github.com/Priivacy-ai/spec-kitty-end-to-end-testing/issues/41))
as a required check on every PR. This PR adds:

- A new workflow
  `.github/workflows/cross-repo-harness-tests.yml` that on every PR
  against `main` (and on push to main) clones
  [`Priivacy-ai/spec-kitty-end-to-end-testing`](https://github.com/Priivacy-ai/spec-kitty-end-to-end-testing)
  at the pinned SHA `03e4d3c04fcdf641cd564badfbc87bb19a2a0982`,
  installs **this PR's events source** as editable into the e2e env
  via `uv pip install -e ../events`, and runs the harness's identity-
  boundary unit tests. The job is named `harness-unit-tests`.
- A README section explaining the gate, the editable-install
  invariant, the pinned-SHA update procedure, and the sibling-repo gates.

The editable-install step is the key invariant: the harness must
exercise the PR's events code, not whatever e2e's lockfile pinned, so
an envelope-shape regression introduced by the PR surfaces here before
the SaaS strict gate sees it in production.

## Evidence

- Mission (in spec-kitty):
  [`kitty-specs/identity-boundary-canary-ci-gate-01KS4XWV/`](https://github.com/Priivacy-ai/spec-kitty/tree/main/kitty-specs/identity-boundary-canary-ci-gate-01KS4XWV)
- Pinned e2e tests:
  [`spec-kitty-end-to-end-testing/tests/unit/identity_boundary/`](https://github.com/Priivacy-ai/spec-kitty-end-to-end-testing/tree/03e4d3c04fcdf641cd564badfbc87bb19a2a0982/tests/unit/identity_boundary)
  and
  [`tests/identity_boundary/unit/`](https://github.com/Priivacy-ai/spec-kitty-end-to-end-testing/tree/03e4d3c04fcdf641cd564badfbc87bb19a2a0982/tests/identity_boundary/unit).

## Action required from repo admin

After this PR merges, a repo admin must register the new check as
required on the branch-protection rule for `main`:

1. Open https://github.com/Priivacy-ai/spec-kitty-events/settings/branches
2. Edit the rule for `main`.
3. Under "Require status checks to pass before merging", click "Add
   status check" and add the exact string:
   ```
   harness-unit-tests
   ```
4. Save the rule.

**Why this matters**: until this admin step lands, the workflow runs
on every PR but its red status does not block merge. The mission's
contract is that the gate is enforced.

### Verification

After enabling the protection rule:

- [ ] Open a trivial follow-up PR (e.g. README typo) and confirm the
  `harness-unit-tests` check runs and goes green.
- [ ] (Optional, with approval) Open a synthetic-violation PR that
  introduces an envelope-shape regression (e.g. rename a required
  field in a lifecycle payload); confirm the check goes red and merge
  is blocked.

## Test plan

- [ ] CI: `harness-unit-tests` job runs on this PR.
- [ ] CI: `harness-unit-tests` job passes (this PR makes no events
  changes, so the harness should be green at the pinned SHA against
  the current events HEAD).
- [ ] No modification to existing workflows.
- [ ] No source-code changes outside `.github/workflows/` and
  `README.md`.

## Tracker

- Closes (when all three sibling PRs merge): part of
  [`Priivacy-ai/spec-kitty#1247`](https://github.com/Priivacy-ai/spec-kitty/issues/1247).
- Drift-class epic:
  [`Priivacy-ai/spec-kitty#1198`](https://github.com/Priivacy-ai/spec-kitty/issues/1198).
