### PR TITLE
Remove queue seed envelope test ignore

### DIFF
--- a/.github/workflows/cross-repo-harness-tests.yml
+++ b/.github/workflows/cross-repo-harness-tests.yml
@@ -68,12 +68,7 @@ jobs:
 
       - name: Run identity-boundary unit tests
         working-directory: e2e
-        # Skipping tests/unit/identity_boundary/test_queue_seed_envelope.py:
-        # it imports a private constant (_CANONICAL_CONSTRUCT_PRELUDE) that
-        # was removed from queue_seed.py in e2e commit 3b90d7f; this is a
-        # pre-existing broken test in the e2e harness, not a defect of this gate.
-        # Track removal at: https://github.com/Priivacy-ai/spec-kitty-end-to-end-testing/issues
-        run: uv run pytest tests/unit/identity_boundary/ tests/identity_boundary/unit/ -v --ignore=tests/unit/identity_boundary/test_queue_seed_envelope.py
+        run: uv run pytest tests/unit/identity_boundary/ tests/identity_boundary/unit/ -v
 
       - name: Upload artifacts on failure
         if: failure()

--- a/.github/workflows/cross-repo-harness-tests.yml
+++ b/.github/workflows/cross-repo-harness-tests.yml
@@ -10,7 +10,7 @@
 # breaks SaaS-side resolution assumptions, the unit suite turns red
 # and merge is blocked.
 #
-# Pinned SHA: 0be4372208f9ac1442c9b2dfae1ec57273cca430
+# Pinned SHA: 193f5c0eb07c8fdb6943d91d205ab892b98d6dfc
 # SHA-bump procedure: see README.md > "Identity-Boundary CI Gate".
 
 name: cross-repo-harness-tests
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Priivacy-ai/spec-kitty-end-to-end-testing
-          ref: 0be4372208f9ac1442c9b2dfae1ec57273cca430
+          ref: 193f5c0eb07c8fdb6943d91d205ab892b98d6dfc
           path: e2e
           ssh-key: ${{ secrets.SK_E2E_READ_DEPLOY_KEY }}
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ assumptions (envelope shape, identity field names, recognition rules), the
 unit suite turns red and merge is blocked. Workflow file:
 [`.github/workflows/cross-repo-harness-tests.yml`](.github/workflows/cross-repo-harness-tests.yml).
 
-**Pinned e2e SHA**: `4d5206e08a30bf23ae4dabae532dc0e355078e16`
+**Pinned e2e SHA**: `193f5c0eb07c8fdb6943d91d205ab892b98d6dfc`
 
 ### SHA-bump procedure
 


### PR DESCRIPTION
## Summary
- remove the temporary --ignore for tests/unit/identity_boundary/test_queue_seed_envelope.py from the cross-repo harness gate
- let the identity-boundary unit workflow run the repaired e2e test normally

Refs Priivacy-ai/spec-kitty-end-to-end-testing#70

## Verification
- python - <<'PY'
import yaml
from pathlib import Path
p = Path('.github/workflows/cross-repo-harness-tests.yml')
yaml.safe_load(p.read_text())
print('workflow yaml ok')
PY