### PR TITLE
feat: add MissionReopened + FollowUpRecorded mission-lifecycle events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.1.0] - 2026-06-14
+
+### Added
+
+- **Canonical contracts for two post-mission lifecycle events** (`MissionReopened`,
+  `FollowUpRecorded`) — additive, wire-compatible. Added `MissionReopenedPayload`
+  and `FollowUpRecordedPayload` pydantic models (`ConfigDict(frozen=True,
+  extra="forbid")`), the `MISSION_REOPENED`/`FOLLOW_UP_RECORDED` type constants,
+  membership in `MISSION_EVENT_TYPES`, package-root re-exports, and
+  `_EVENT_TYPE_TO_MODEL` registry entries. Field shapes mirror the producer call
+  sites in `spec-kitty/src/specify_cli/status/lifecycle_events.py`
+  (`emit_mission_reopened` / `emit_follow_up_recorded`) and the mission
+  data-model `mission-lifecycle-dispatch-drg-closeout-01KV0S99/data-model.md`.
+  `MissionReopened` carries `mission_id`, `mission_slug`, `reason`, `reopened_by`,
+  `reopened_at`, and optional `cleared_merge`. `FollowUpRecorded` carries
+  `mission_id`, `mission_slug`, a `follow_up_type` discriminator (`"commit"`/`"pr"`),
+  conditional `commit_sha`/`pr_number`, `recorded_by`, and `recorded_at`; a
+  model-level validator enforces the commit-vs-pr conditional-required rule.
+  Consumer: spec-kitty mission `01KV0S99` (PR Priivacy-ai/spec-kitty#1926).
+  No JSON-schema entry yet (the schema layer is optional secondary).
+
 ## [6.0.0] - 2026-06-07
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   model-level validator enforces the commit-vs-pr conditional-required rule.
   Consumer: spec-kitty mission `01KV0S99` (PR Priivacy-ai/spec-kitty#1926).
   No JSON-schema entry yet (the schema layer is optional secondary).
+- **`reduce_lifecycle_events` post-mission semantics** for the two new events.
+  Because `MissionReopened`/`FollowUpRecorded` are members of
+  `MISSION_EVENT_TYPES`, they now flow through the lifecycle reducer with
+  explicit handlers placed *before* the generic post-terminal guard (which would
+  otherwise misfire and flag them as `Event after terminal state` anomalies).
+  A `MissionReopened` is valid only when the mission is terminal and transitions
+  it to the new actionable `MissionStatus.REOPENED` state (non-terminal, so a
+  fresh `MissionCompleted` is processed normally); a `FollowUpRecorded` is valid
+  only when terminal and leaves `mission_status` unchanged (a recorded fact).
+  Inverse contract: either event arriving before completion (mission not in a
+  terminal state) is itself flagged as a `… before completion` anomaly. All
+  other event semantics and existing anomaly detection are preserved.
+- `MissionStatus.REOPENED = "reopened"` enum member (actionable, NOT in
+  `TERMINAL_MISSION_STATUSES`).
 
 ## [6.0.0] - 2026-06-07
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spec-kitty-events"
-version = "6.0.0"
+version = "6.1.0"
 description = "Event log library with Lamport clocks and systematic error tracking"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/spec_kitty_events/__init__.py
+++ b/src/spec_kitty_events/__init__.py
@@ -13,7 +13,7 @@ This release publishes the fail-closed cutover surface for:
   historical-shape conformance fixtures.
 """
 
-__version__ = "6.0.0"
+__version__ = "6.1.0"
 
 from spec_kitty_events.cutover import (
     CUTOVER_ARTIFACT,
@@ -95,6 +95,8 @@ from spec_kitty_events.lifecycle import (
     MISSION_COMPLETED,
     MISSION_CANCELLED,
     MISSION_ORIGIN_BOUND,
+    MISSION_REOPENED,
+    FOLLOW_UP_RECORDED,
     PHASE_ENTERED,
     REVIEW_ROLLBACK,
     MISSION_EVENT_TYPES,
@@ -106,6 +108,8 @@ from spec_kitty_events.lifecycle import (
     MissionCompletedPayload,
     MissionCancelledPayload,
     MissionOriginBoundPayload,
+    MissionReopenedPayload,
+    FollowUpRecordedPayload,
     PhaseEnteredPayload,
     ReviewRollbackPayload,
     LifecycleAnomaly,
@@ -902,6 +906,12 @@ __all__ = [
     "DependencyResolvedPayload",
     "MISSION_ORIGIN_BOUND",
     "MissionOriginBoundPayload",
+    # Post-mission lifecycle events
+    # (mission-lifecycle-dispatch-drg-closeout-01KV0S99).
+    "MISSION_REOPENED",
+    "FOLLOW_UP_RECORDED",
+    "MissionReopenedPayload",
+    "FollowUpRecordedPayload",
     "BUILD_REGISTERED",
     "BUILD_HEARTBEAT",
     "BUILD_LIFECYCLE_EVENT_TYPES",

--- a/src/spec_kitty_events/conformance/validators.py
+++ b/src/spec_kitty_events/conformance/validators.py
@@ -22,11 +22,13 @@ from spec_kitty_events.build_lifecycle import (
 )
 from spec_kitty_events.gates import GateFailedPayload, GatePassedPayload
 from spec_kitty_events.lifecycle import (
+    FollowUpRecordedPayload,
     MissionClosedPayload,
     MissionCancelledPayload,
     MissionCompletedPayload,
     MissionCreatedPayload,
     MissionOriginBoundPayload,
+    MissionReopenedPayload,
     MissionStartedPayload,
     PhaseEnteredPayload,
     ReviewRollbackPayload,
@@ -281,6 +283,13 @@ _EVENT_TYPE_TO_MODEL: Dict[str, Any] = {
     "ErrorLogged": ErrorLoggedPayload,
     "DependencyResolved": DependencyResolvedPayload,
     "MissionOriginBound": MissionOriginBoundPayload,
+    # Post-mission lifecycle events (mission
+    # mission-lifecycle-dispatch-drg-closeout-01KV0S99). Producer call sites:
+    # spec-kitty/src/specify_cli/status/lifecycle_events.py
+    # (emit_mission_reopened / emit_follow_up_recorded). Model-layer only —
+    # no JSON schema entry yet (the schema layer is optional secondary).
+    "MissionReopened": MissionReopenedPayload,
+    "FollowUpRecorded": FollowUpRecordedPayload,
 }
 
 # Event type to JSON Schema name mapping (used with load_schema())

--- a/src/spec_kitty_events/lifecycle.py
+++ b/src/spec_kitty_events/lifecycle.py
@@ -15,9 +15,9 @@ Sections:
 from __future__ import annotations
 
 from enum import Enum
-from typing import Dict, FrozenSet, List, Optional, Sequence, Tuple
+from typing import Any, Dict, FrozenSet, List, Literal, Optional, Sequence, Tuple
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 # ── Section 1: Constants ─────────────────────────────────────────────────────
 
@@ -33,6 +33,16 @@ MISSION_ORIGIN_BOUND: str = "MissionOriginBound"
 PHASE_ENTERED: str = "PhaseEntered"
 REVIEW_ROLLBACK: str = "ReviewRollback"
 
+# Post-mission lifecycle events. These record facts about a mission *after* it
+# has merged/closed: a re-open returning it to an actionable state, and a
+# follow-up commit/PR attributed to it. Producer call site:
+# spec-kitty/src/specify_cli/status/lifecycle_events.py
+# (emit_mission_reopened / emit_follow_up_recorded). Field shapes mirror the
+# producer payloads and the mission data-model
+# (kitty-specs/mission-lifecycle-dispatch-drg-closeout-01KV0S99/data-model.md).
+MISSION_REOPENED: str = "MissionReopened"
+FOLLOW_UP_RECORDED: str = "FollowUpRecorded"
+
 MISSION_EVENT_TYPES: FrozenSet[str] = frozenset({
     MISSION_CREATED,
     MISSION_CLOSED,
@@ -41,6 +51,8 @@ MISSION_EVENT_TYPES: FrozenSet[str] = frozenset({
     MISSION_CANCELLED,
     PHASE_ENTERED,
     REVIEW_ROLLBACK,
+    MISSION_REOPENED,
+    FOLLOW_UP_RECORDED,
 })
 
 # ── Section 2: MissionStatus Enum ────────────────────────────────────────────
@@ -192,6 +204,94 @@ class MissionOriginBoundPayload(BaseModel):
     external_issue_url: str = Field(..., min_length=1, description="Browser URL to the external issue.")
     title: str = Field(..., min_length=1, description="External issue title.")
     mission_id: Optional[str] = Field(None, min_length=1, description="Canonical mission ULID (when known).")
+
+
+class MissionReopenedPayload(BaseModel):
+    """Typed payload for ``MissionReopened`` events.
+
+    Records that a merged/closed mission was returned to an actionable state.
+    Appended *each* time (every re-open is a distinct fact — NOT deduped).
+    Attribution is via ``mission_id`` (ULID); ``cleared_merge`` is an optional
+    snapshot of the ``merged_*`` fields removed from ``meta.json`` by the
+    re-open command, retained for audit / reversibility.
+
+    Producer: ``spec-kitty/src/specify_cli/status/lifecycle_events.py``
+    ``emit_mission_reopened``. Data-model:
+    ``mission-lifecycle-dispatch-drg-closeout-01KV0S99/data-model.md``.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    mission_id: str = Field(
+        ..., min_length=1, description="Canonical machine identity (ULID); lookup key."
+    )
+    mission_slug: str = Field(
+        ..., min_length=1, description="Human handle (display)."
+    )
+    reason: str = Field(
+        ..., min_length=1, description="Audit reason for the re-open (non-empty)."
+    )
+    reopened_by: str = Field(
+        ..., min_length=1, description="Detected actor who re-opened the mission."
+    )
+    reopened_at: str = Field(
+        ..., min_length=1, description="Event time (ISO-8601 UTC)."
+    )
+    cleared_merge: Optional[Dict[str, Any]] = Field(
+        None,
+        description="Snapshot of the merged_* fields cleared from meta.json "
+        "(for reversibility/audit); null when no merge metadata was cleared.",
+    )
+
+
+class FollowUpRecordedPayload(BaseModel):
+    """Typed payload for ``FollowUpRecorded`` events.
+
+    Records a follow-up commit or PR against an already-merged (or any-state)
+    mission. ``follow_up_type`` is the discriminator: ``"commit"`` requires
+    ``commit_sha``; ``"pr"`` requires ``pr_number``. Attribution is via
+    ``mission_id``. A commit and the PR that contains it are recorded as
+    distinct facts (no resolved-commit-of-PR lookup).
+
+    Producer: ``spec-kitty/src/specify_cli/status/lifecycle_events.py``
+    ``emit_follow_up_recorded``. Data-model:
+    ``mission-lifecycle-dispatch-drg-closeout-01KV0S99/data-model.md``.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    mission_id: str = Field(
+        ..., min_length=1, description="Canonical machine identity (ULID); attribution key."
+    )
+    mission_slug: str = Field(
+        ..., min_length=1, description="Human handle (display)."
+    )
+    follow_up_type: Literal["commit", "pr"] = Field(
+        ..., description="Discriminator: 'commit' (requires commit_sha) or 'pr' (requires pr_number)."
+    )
+    commit_sha: Optional[str] = Field(
+        None, min_length=1, description="Commit SHA; required iff follow_up_type == 'commit'."
+    )
+    pr_number: Optional[int] = Field(
+        None, ge=1, description="PR number; required iff follow_up_type == 'pr'."
+    )
+    recorded_by: str = Field(
+        ..., min_length=1, description="Detected actor who recorded the follow-up."
+    )
+    recorded_at: str = Field(
+        ..., min_length=1, description="Event time (ISO-8601 UTC)."
+    )
+
+    @model_validator(mode="after")
+    def _check_discriminator(self) -> "FollowUpRecordedPayload":
+        """Enforce the commit-vs-pr conditional-required contract."""
+        if self.follow_up_type == "commit":
+            if not self.commit_sha:
+                raise ValueError("commit_sha is required when follow_up_type == 'commit'")
+        elif self.follow_up_type == "pr":
+            if self.pr_number is None:
+                raise ValueError("pr_number is required when follow_up_type == 'pr'")
+        return self
 
 
 class PhaseEnteredPayload(BaseModel):

--- a/src/spec_kitty_events/lifecycle.py
+++ b/src/spec_kitty_events/lifecycle.py
@@ -59,11 +59,20 @@ MISSION_EVENT_TYPES: FrozenSet[str] = frozenset({
 
 
 class MissionStatus(str, Enum):
-    """Mission lifecycle states."""
+    """Mission lifecycle states.
+
+    ``REOPENED`` is an *actionable* (non-terminal) state distinct from
+    ``ACTIVE``: it records that a previously-completed/cancelled mission was
+    returned to an actionable state by a ``MissionReopened`` event. It is
+    deliberately NOT in :data:`TERMINAL_MISSION_STATUSES`, so subsequent
+    lifecycle events (e.g. a fresh ``MissionCompleted``) are processed
+    normally rather than flagged as post-terminal anomalies.
+    """
 
     ACTIVE = "active"
     COMPLETED = "completed"
     CANCELLED = "cancelled"
+    REOPENED = "reopened"
 
 
 TERMINAL_MISSION_STATUSES: FrozenSet[MissionStatus] = frozenset({
@@ -437,6 +446,64 @@ def _process_mission_event(
                     reason="Invalid MissionClosed payload",
                 )
             )
+        return mission_id, mission_status, mission_type, current_phase
+
+    # Post-mission events (MissionReopened / FollowUpRecorded) are valid ONLY
+    # after the mission has reached a terminal/completed state. They must be
+    # handled BEFORE the generic terminal-state guard below — otherwise that
+    # guard would misfire and flag these by-design post-completion facts as
+    # "Event after terminal state" anomalies.
+    #
+    # The contract is symmetric: a post-mission event that arrives when the
+    # mission is NOT terminal (no prior completion/cancellation) is itself the
+    # anomaly ("post-mission event before completion").
+    if event.event_type == MISSION_REOPENED:
+        try:
+            MissionReopenedPayload(**event.payload)
+        except Exception:
+            anomalies.append(
+                LifecycleAnomaly(
+                    event_id=event.event_id,
+                    event_type=event.event_type,
+                    reason="Invalid MissionReopened payload",
+                )
+            )
+            return mission_id, mission_status, mission_type, current_phase
+        if mission_status not in TERMINAL_MISSION_STATUSES:
+            anomalies.append(
+                LifecycleAnomaly(
+                    event_id=event.event_id,
+                    event_type=event.event_type,
+                    reason="MissionReopened before completion (mission not terminal)",
+                )
+            )
+            return mission_id, mission_status, mission_type, current_phase
+        # Valid re-open: transition out of terminal back to an actionable state.
+        mission_status = MissionStatus.REOPENED
+        return mission_id, mission_status, mission_type, current_phase
+
+    if event.event_type == FOLLOW_UP_RECORDED:
+        try:
+            FollowUpRecordedPayload(**event.payload)
+        except Exception:
+            anomalies.append(
+                LifecycleAnomaly(
+                    event_id=event.event_id,
+                    event_type=event.event_type,
+                    reason="Invalid FollowUpRecorded payload",
+                )
+            )
+            return mission_id, mission_status, mission_type, current_phase
+        if mission_status not in TERMINAL_MISSION_STATUSES:
+            anomalies.append(
+                LifecycleAnomaly(
+                    event_id=event.event_id,
+                    event_type=event.event_type,
+                    reason="FollowUpRecorded before completion (mission not terminal)",
+                )
+            )
+            return mission_id, mission_status, mission_type, current_phase
+        # Valid follow-up: a recorded fact; mission_status is UNCHANGED.
         return mission_id, mission_status, mission_type, current_phase
 
     # Check: event after terminal state

--- a/tests/integration/test_lifecycle_replay.py
+++ b/tests/integration/test_lifecycle_replay.py
@@ -17,17 +17,20 @@ from ulid import ULID
 
 from spec_kitty_events.decisionpoint import reduce_decision_point_events
 from spec_kitty_events.lifecycle import (
+    FOLLOW_UP_RECORDED,
     MISSION_CANCELLED,
     MISSION_COMPLETED,
+    MISSION_REOPENED,
     MISSION_STARTED,
     PHASE_ENTERED,
     REVIEW_ROLLBACK,
+    FollowUpRecordedPayload,
     MissionCancelledPayload,
     MissionCompletedPayload,
+    MissionReopenedPayload,
     MissionStartedPayload,
     MissionStatus,
     PhaseEnteredPayload,
-    ReducedMissionState,
     ReviewRollbackPayload,
     reduce_lifecycle_events,
 )
@@ -409,6 +412,128 @@ class TestFullLifecycleAllEventTypes:
         assert state.mission_status == MissionStatus.COMPLETED
         assert len(state.anomalies) == 1
         assert "terminal" in state.anomalies[0].reason.lower()
+
+    def test_completed_then_reopened_leaves_terminal(self) -> None:
+        """Post-completion MissionReopened is valid and exits terminal."""
+        corr_id = str(ULID())
+        events = [
+            _make_event(
+                MISSION_STARTED,
+                MissionStartedPayload(
+                    mission_id="M001",
+                    mission_type="software-dev",
+                    initial_phase="specify",
+                    actor="user-1",
+                ).model_dump(),
+                lamport_clock=1,
+                corr_id=corr_id,
+            ),
+            _make_event(
+                MISSION_COMPLETED,
+                MissionCompletedPayload(
+                    mission_id="M001",
+                    mission_type="software-dev",
+                    final_phase="review",
+                    actor="user-1",
+                ).model_dump(),
+                lamport_clock=2,
+                corr_id=corr_id,
+            ),
+            _make_event(
+                MISSION_REOPENED,
+                MissionReopenedPayload(
+                    mission_id="M001",
+                    mission_slug="mission-reopen-followup",
+                    reason="Land a follow-up fix",
+                    reopened_by="stijn",
+                    reopened_at="2026-06-14T12:00:00+00:00",
+                ).model_dump(),
+                lamport_clock=3,
+                corr_id=corr_id,
+            ),
+        ]
+        state = reduce_lifecycle_events(events)
+        assert state.mission_status == MissionStatus.REOPENED
+        assert len(state.anomalies) == 0
+        # Replay determinism.
+        assert reduce_lifecycle_events(list(events)) == state
+
+    def test_completed_then_follow_up_keeps_status(self) -> None:
+        """Post-completion FollowUpRecorded is valid; status unchanged."""
+        corr_id = str(ULID())
+        events = [
+            _make_event(
+                MISSION_STARTED,
+                MissionStartedPayload(
+                    mission_id="M001",
+                    mission_type="software-dev",
+                    initial_phase="specify",
+                    actor="user-1",
+                ).model_dump(),
+                lamport_clock=1,
+                corr_id=corr_id,
+            ),
+            _make_event(
+                MISSION_COMPLETED,
+                MissionCompletedPayload(
+                    mission_id="M001",
+                    mission_type="software-dev",
+                    final_phase="review",
+                    actor="user-1",
+                ).model_dump(),
+                lamport_clock=2,
+                corr_id=corr_id,
+            ),
+            _make_event(
+                FOLLOW_UP_RECORDED,
+                FollowUpRecordedPayload(
+                    mission_id="M001",
+                    mission_slug="mission-reopen-followup",
+                    follow_up_type="pr",
+                    pr_number=1926,
+                    recorded_by="stijn",
+                    recorded_at="2026-06-14T12:00:00+00:00",
+                ).model_dump(),
+                lamport_clock=3,
+                corr_id=corr_id,
+            ),
+        ]
+        state = reduce_lifecycle_events(events)
+        assert state.mission_status == MissionStatus.COMPLETED
+        assert len(state.anomalies) == 0
+
+    def test_reopen_before_completion_is_anomaly(self) -> None:
+        """Pre-completion MissionReopened is the anomaly (inverse contract)."""
+        corr_id = str(ULID())
+        events = [
+            _make_event(
+                MISSION_STARTED,
+                MissionStartedPayload(
+                    mission_id="M001",
+                    mission_type="software-dev",
+                    initial_phase="specify",
+                    actor="user-1",
+                ).model_dump(),
+                lamport_clock=1,
+                corr_id=corr_id,
+            ),
+            _make_event(
+                MISSION_REOPENED,
+                MissionReopenedPayload(
+                    mission_id="M001",
+                    mission_slug="mission-reopen-followup",
+                    reason="Premature re-open",
+                    reopened_by="stijn",
+                    reopened_at="2026-06-14T12:00:00+00:00",
+                ).model_dump(),
+                lamport_clock=2,
+                corr_id=corr_id,
+            ),
+        ]
+        state = reduce_lifecycle_events(events)
+        assert state.mission_status == MissionStatus.ACTIVE
+        assert len(state.anomalies) == 1
+        assert "before completion" in state.anomalies[0].reason
 
 
 # ── V1 DecisionPoint golden replay tests ─────────────────────────────────────

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -8,21 +8,25 @@ from pydantic import ValidationError as PydanticValidationError
 from ulid import ULID
 
 from spec_kitty_events.lifecycle import (
+    FOLLOW_UP_RECORDED,
     MISSION_CLOSED,
     MISSION_CANCELLED,
     MISSION_COMPLETED,
     MISSION_CREATED,
     MISSION_EVENT_TYPES,
+    MISSION_REOPENED,
     MISSION_STARTED,
     PHASE_ENTERED,
     REVIEW_ROLLBACK,
     SCHEMA_VERSION,
     TERMINAL_MISSION_STATUSES,
+    FollowUpRecordedPayload,
     LifecycleAnomaly,
     MissionClosedPayload,
     MissionCancelledPayload,
     MissionCompletedPayload,
     MissionCreatedPayload,
+    MissionReopenedPayload,
     MissionStartedPayload,
     MissionStatus,
     PhaseEnteredPayload,
@@ -131,6 +135,12 @@ class TestConstants:
     def test_review_rollback(self) -> None:
         assert REVIEW_ROLLBACK == "ReviewRollback"
 
+    def test_mission_reopened(self) -> None:
+        assert MISSION_REOPENED == "MissionReopened"
+
+    def test_follow_up_recorded(self) -> None:
+        assert FOLLOW_UP_RECORDED == "FollowUpRecorded"
+
     def test_mission_event_types_contains_all(self) -> None:
         assert MISSION_CREATED in MISSION_EVENT_TYPES
         assert MISSION_CLOSED in MISSION_EVENT_TYPES
@@ -139,7 +149,9 @@ class TestConstants:
         assert MISSION_CANCELLED in MISSION_EVENT_TYPES
         assert PHASE_ENTERED in MISSION_EVENT_TYPES
         assert REVIEW_ROLLBACK in MISSION_EVENT_TYPES
-        assert len(MISSION_EVENT_TYPES) == 7
+        assert MISSION_REOPENED in MISSION_EVENT_TYPES
+        assert FOLLOW_UP_RECORDED in MISSION_EVENT_TYPES
+        assert len(MISSION_EVENT_TYPES) == 9
 
     def test_mission_event_types_frozen(self) -> None:
         assert isinstance(MISSION_EVENT_TYPES, frozenset)
@@ -1023,3 +1035,227 @@ class TestReduceLifecycleEvents:
         assert result.mission_id == "M001"  # First one wins
         assert len(result.anomalies) == 1
         assert "Duplicate" in result.anomalies[0].reason
+
+
+# ── MissionReopenedPayload ───────────────────────────────────────────────────
+
+
+class TestMissionReopenedPayload:
+    """Tests for MissionReopenedPayload model."""
+
+    def _valid(self, **overrides: object) -> dict:  # type: ignore[type-arg]
+        payload: dict = {  # type: ignore[type-arg]
+            "mission_id": "01KTESTMISSIONID0000000000",
+            "mission_slug": "mission-reopen-followup",
+            "reason": "Operator requested re-open to land follow-up fix",
+            "reopened_by": "stijn",
+            "reopened_at": "2026-06-14T12:00:00+00:00",
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_valid_construction(self) -> None:
+        p = MissionReopenedPayload(**self._valid())
+        assert p.mission_id == "01KTESTMISSIONID0000000000"
+        assert p.mission_slug == "mission-reopen-followup"
+        assert p.reason.startswith("Operator")
+        assert p.reopened_by == "stijn"
+        assert p.cleared_merge is None
+
+    def test_optional_cleared_merge_accepted(self) -> None:
+        p = MissionReopenedPayload(
+            **self._valid(
+                cleared_merge={
+                    "merged_at": "2026-06-10T00:00:00+00:00",
+                    "merged_commit": "abc123",
+                }
+            )
+        )
+        assert p.cleared_merge == {
+            "merged_at": "2026-06-10T00:00:00+00:00",
+            "merged_commit": "abc123",
+        }
+
+    def test_missing_mission_id(self) -> None:
+        payload = self._valid()
+        del payload["mission_id"]
+        with pytest.raises(PydanticValidationError):
+            MissionReopenedPayload(**payload)  # type: ignore[arg-type]
+
+    def test_missing_reason(self) -> None:
+        payload = self._valid()
+        del payload["reason"]
+        with pytest.raises(PydanticValidationError):
+            MissionReopenedPayload(**payload)  # type: ignore[arg-type]
+
+    def test_empty_reason_rejected(self) -> None:
+        with pytest.raises(PydanticValidationError):
+            MissionReopenedPayload(**self._valid(reason=""))
+
+    def test_missing_reopened_by(self) -> None:
+        payload = self._valid()
+        del payload["reopened_by"]
+        with pytest.raises(PydanticValidationError):
+            MissionReopenedPayload(**payload)  # type: ignore[arg-type]
+
+    def test_rejects_extra_fields(self) -> None:
+        with pytest.raises(PydanticValidationError):
+            MissionReopenedPayload(**self._valid(unexpected="x"))
+
+    def test_frozen(self) -> None:
+        p = MissionReopenedPayload(**self._valid())
+        with pytest.raises(Exception):
+            setattr(p, "reason", "changed")
+
+    def test_round_trip(self) -> None:
+        p = MissionReopenedPayload(
+            **self._valid(cleared_merge={"merged_commit": "abc123"})
+        )
+        restored = MissionReopenedPayload(**p.model_dump(mode="json"))
+        assert restored == p
+
+
+# ── FollowUpRecordedPayload ──────────────────────────────────────────────────
+
+
+class TestFollowUpRecordedPayload:
+    """Tests for FollowUpRecordedPayload model."""
+
+    def _commit(self, **overrides: object) -> dict:  # type: ignore[type-arg]
+        payload: dict = {  # type: ignore[type-arg]
+            "mission_id": "01KTESTMISSIONID0000000000",
+            "mission_slug": "mission-reopen-followup",
+            "follow_up_type": "commit",
+            "commit_sha": "a" * 40,
+            "pr_number": None,
+            "recorded_by": "stijn",
+            "recorded_at": "2026-06-14T12:00:00+00:00",
+        }
+        payload.update(overrides)
+        return payload
+
+    def _pr(self, **overrides: object) -> dict:  # type: ignore[type-arg]
+        payload: dict = {  # type: ignore[type-arg]
+            "mission_id": "01KTESTMISSIONID0000000000",
+            "mission_slug": "mission-reopen-followup",
+            "follow_up_type": "pr",
+            "commit_sha": None,
+            "pr_number": 1926,
+            "recorded_by": "stijn",
+            "recorded_at": "2026-06-14T12:00:00+00:00",
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_valid_commit(self) -> None:
+        p = FollowUpRecordedPayload(**self._commit())
+        assert p.follow_up_type == "commit"
+        assert p.commit_sha == "a" * 40
+        assert p.pr_number is None
+
+    def test_valid_pr(self) -> None:
+        p = FollowUpRecordedPayload(**self._pr())
+        assert p.follow_up_type == "pr"
+        assert p.pr_number == 1926
+        assert p.commit_sha is None
+
+    def test_invalid_follow_up_type_rejected(self) -> None:
+        with pytest.raises(PydanticValidationError):
+            FollowUpRecordedPayload(**self._commit(follow_up_type="branch"))
+
+    def test_commit_type_requires_commit_sha(self) -> None:
+        with pytest.raises(PydanticValidationError):
+            FollowUpRecordedPayload(**self._commit(commit_sha=None))
+
+    def test_pr_type_requires_pr_number(self) -> None:
+        with pytest.raises(PydanticValidationError):
+            FollowUpRecordedPayload(**self._pr(pr_number=None))
+
+    def test_pr_number_must_be_positive(self) -> None:
+        with pytest.raises(PydanticValidationError):
+            FollowUpRecordedPayload(**self._pr(pr_number=0))
+
+    def test_missing_mission_id(self) -> None:
+        payload = self._commit()
+        del payload["mission_id"]
+        with pytest.raises(PydanticValidationError):
+            FollowUpRecordedPayload(**payload)  # type: ignore[arg-type]
+
+    def test_missing_recorded_by(self) -> None:
+        payload = self._commit()
+        del payload["recorded_by"]
+        with pytest.raises(PydanticValidationError):
+            FollowUpRecordedPayload(**payload)  # type: ignore[arg-type]
+
+    def test_rejects_extra_fields(self) -> None:
+        with pytest.raises(PydanticValidationError):
+            FollowUpRecordedPayload(**self._commit(unexpected="x"))
+
+    def test_frozen(self) -> None:
+        p = FollowUpRecordedPayload(**self._commit())
+        with pytest.raises(Exception):
+            setattr(p, "follow_up_type", "pr")
+
+    def test_round_trip_commit(self) -> None:
+        p = FollowUpRecordedPayload(**self._commit())
+        restored = FollowUpRecordedPayload(**p.model_dump(mode="json"))
+        assert restored == p
+
+    def test_round_trip_pr(self) -> None:
+        p = FollowUpRecordedPayload(**self._pr())
+        restored = FollowUpRecordedPayload(**p.model_dump(mode="json"))
+        assert restored == p
+
+
+# ── Conformance registry presence ────────────────────────────────────────────
+
+
+class TestPostMissionRegistryPresence:
+    """The new events must be reachable through the conformance model map."""
+
+    def test_events_registered_in_model_map(self) -> None:
+        from spec_kitty_events.conformance.validators import _EVENT_TYPE_TO_MODEL
+
+        assert _EVENT_TYPE_TO_MODEL[MISSION_REOPENED] is MissionReopenedPayload
+        assert _EVENT_TYPE_TO_MODEL[FOLLOW_UP_RECORDED] is FollowUpRecordedPayload
+
+    def test_validate_event_accepts_valid_payloads(self) -> None:
+        from spec_kitty_events.conformance import validate_event
+
+        reopened = {
+            "mission_id": "01KTESTMISSIONID0000000000",
+            "mission_slug": "mission-reopen-followup",
+            "reason": "land follow-up",
+            "reopened_by": "stijn",
+            "reopened_at": "2026-06-14T12:00:00+00:00",
+            "cleared_merge": None,
+        }
+        result = validate_event(reopened, MISSION_REOPENED)
+        assert not result.model_violations
+
+        follow_up = {
+            "mission_id": "01KTESTMISSIONID0000000000",
+            "mission_slug": "mission-reopen-followup",
+            "follow_up_type": "pr",
+            "commit_sha": None,
+            "pr_number": 1926,
+            "recorded_by": "stijn",
+            "recorded_at": "2026-06-14T12:00:00+00:00",
+        }
+        result = validate_event(follow_up, FOLLOW_UP_RECORDED)
+        assert not result.model_violations
+
+    def test_validate_event_flags_invalid_discriminator(self) -> None:
+        from spec_kitty_events.conformance import validate_event
+
+        bad = {
+            "mission_id": "01KTESTMISSIONID0000000000",
+            "mission_slug": "mission-reopen-followup",
+            "follow_up_type": "commit",
+            "commit_sha": None,
+            "pr_number": None,
+            "recorded_by": "stijn",
+            "recorded_at": "2026-06-14T12:00:00+00:00",
+        }
+        result = validate_event(bad, FOLLOW_UP_RECORDED)
+        assert result.model_violations

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -1037,6 +1037,163 @@ class TestReduceLifecycleEvents:
         assert "Duplicate" in result.anomalies[0].reason
 
 
+# ── Post-mission reducer semantics (MissionReopened / FollowUpRecorded) ───────
+
+
+class TestPostMissionReducerSemantics:
+    """reduce_lifecycle_events() post-completion semantics.
+
+    Contract: MissionReopened and FollowUpRecorded are valid ONLY after the
+    mission reached a terminal state. Post-completion → no anomaly; a re-open
+    leaves terminal (REOPENED), a follow-up is a recorded fact (status
+    unchanged). Pre-completion → the event itself is the anomaly.
+    """
+
+    def _started(self, lamport: int = 1) -> Event:
+        return _make_mission_event(
+            MISSION_STARTED,
+            MissionStartedPayload(
+                mission_id="M001",
+                mission_type="software-dev",
+                initial_phase="specify",
+                actor="user-1",
+            ).model_dump(),
+            lamport_clock=lamport,
+        )
+
+    def _completed(self, lamport: int = 2) -> Event:
+        return _make_mission_event(
+            MISSION_COMPLETED,
+            MissionCompletedPayload(
+                mission_id="M001",
+                mission_type="software-dev",
+                final_phase="review",
+                actor="user-1",
+            ).model_dump(),
+            lamport_clock=lamport,
+        )
+
+    def _reopened(self, lamport: int = 3) -> Event:
+        return _make_mission_event(
+            MISSION_REOPENED,
+            MissionReopenedPayload(
+                mission_id="M001",
+                mission_slug="mission-reopen-followup",
+                reason="Operator requested re-open to land follow-up fix",
+                reopened_by="stijn",
+                reopened_at="2026-06-14T12:00:00+00:00",
+            ).model_dump(),
+            lamport_clock=lamport,
+        )
+
+    def _follow_up(self, lamport: int = 3) -> Event:
+        return _make_mission_event(
+            FOLLOW_UP_RECORDED,
+            FollowUpRecordedPayload(
+                mission_id="M001",
+                mission_slug="mission-reopen-followup",
+                follow_up_type="commit",
+                commit_sha="a" * 40,
+                recorded_by="stijn",
+                recorded_at="2026-06-14T12:00:00+00:00",
+            ).model_dump(),
+            lamport_clock=lamport,
+        )
+
+    def test_reopen_after_completion_is_not_anomaly(self) -> None:
+        result = reduce_lifecycle_events(
+            [self._started(), self._completed(), self._reopened()]
+        )
+        assert result.anomalies == ()
+        # Re-open transitions the mission OUT of terminal.
+        assert result.mission_status == MissionStatus.REOPENED
+        assert result.mission_status not in TERMINAL_MISSION_STATUSES
+        assert result.event_count == 3
+
+    def test_follow_up_after_completion_is_not_anomaly_and_status_unchanged(
+        self,
+    ) -> None:
+        result = reduce_lifecycle_events(
+            [self._started(), self._completed(), self._follow_up()]
+        )
+        assert result.anomalies == ()
+        # FollowUpRecorded is a recorded fact: status stays terminal.
+        assert result.mission_status == MissionStatus.COMPLETED
+        assert result.event_count == 3
+
+    def test_reopen_before_completion_is_anomaly(self) -> None:
+        result = reduce_lifecycle_events([self._started(), self._reopened(lamport=2)])
+        assert result.mission_status == MissionStatus.ACTIVE
+        assert len(result.anomalies) == 1
+        assert result.anomalies[0].event_type == MISSION_REOPENED
+        assert "before completion" in result.anomalies[0].reason
+
+    def test_follow_up_before_completion_is_anomaly(self) -> None:
+        result = reduce_lifecycle_events(
+            [self._started(), self._follow_up(lamport=2)]
+        )
+        assert result.mission_status == MissionStatus.ACTIVE
+        assert len(result.anomalies) == 1
+        assert result.anomalies[0].event_type == FOLLOW_UP_RECORDED
+        assert "before completion" in result.anomalies[0].reason
+
+    def test_reopen_then_complete_again_processes_normally(self) -> None:
+        """After a valid re-open, status is non-terminal so a fresh
+        MissionCompleted is applied without a post-terminal anomaly."""
+        result = reduce_lifecycle_events(
+            [
+                self._started(),
+                self._completed(lamport=2),
+                self._reopened(lamport=3),
+                self._completed(lamport=4),
+            ]
+        )
+        assert result.anomalies == ()
+        assert result.mission_status == MissionStatus.COMPLETED
+        assert result.event_count == 4
+
+    def test_invalid_reopen_payload_after_completion_is_anomaly(self) -> None:
+        bad = _make_mission_event(
+            MISSION_REOPENED,
+            {"mission_id": "M001"},  # missing required fields
+            lamport_clock=3,
+        )
+        result = reduce_lifecycle_events([self._started(), self._completed(), bad])
+        assert result.mission_status == MissionStatus.COMPLETED
+        assert len(result.anomalies) == 1
+        assert "Invalid MissionReopened payload" == result.anomalies[0].reason
+
+    def test_invalid_follow_up_payload_after_completion_is_anomaly(self) -> None:
+        bad = _make_mission_event(
+            FOLLOW_UP_RECORDED,
+            {"mission_id": "M001", "follow_up_type": "commit"},  # missing commit_sha
+            lamport_clock=3,
+        )
+        result = reduce_lifecycle_events([self._started(), self._completed(), bad])
+        assert result.mission_status == MissionStatus.COMPLETED
+        assert len(result.anomalies) == 1
+        assert "Invalid FollowUpRecorded payload" == result.anomalies[0].reason
+
+    def test_follow_up_does_not_leave_terminal_for_next_guard(self) -> None:
+        """A follow-up keeps the mission terminal, so a later by-design
+        anomaly event (e.g. PhaseEntered) is still flagged."""
+        late_phase = _make_mission_event(
+            PHASE_ENTERED,
+            PhaseEnteredPayload(
+                mission_id="M001",
+                phase_name="implement",
+                actor="user-1",
+            ).model_dump(),
+            lamport_clock=4,
+        )
+        result = reduce_lifecycle_events(
+            [self._started(), self._completed(), self._follow_up(), late_phase]
+        )
+        assert result.mission_status == MissionStatus.COMPLETED
+        assert len(result.anomalies) == 1
+        assert "terminal" in result.anomalies[0].reason.lower()
+
+
 # ── MissionReopenedPayload ───────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Adds canonical event contracts for two **post-mission lifecycle events** that the spec-kitty producer already emits but that this package did not yet recognise.

- **Consumer:** spec-kitty mission `01KV0S99` (PR Priivacy-ai/spec-kitty#1926). The producer emits these from `src/specify_cli/status/lifecycle_events.py` (`emit_mission_reopened` / `emit_follow_up_recorded`); they need the canonical contract here so they can eventually route through strict validation / SaaS.
- **Additive / backward-compatible** minor bump `6.0.0` → `6.1.0`. On-wire `schema_version` unchanged at `3.0.0` (no envelope shape change).

## What's added

- `MISSION_REOPENED = "MissionReopened"`, `FOLLOW_UP_RECORDED = "FollowUpRecorded"` constants; both added to `MISSION_EVENT_TYPES`.
- `MissionReopenedPayload` — `mission_id`, `mission_slug`, `reason`, `reopened_by`, `reopened_at`, optional `cleared_merge`.
- `FollowUpRecordedPayload` — `mission_id`, `mission_slug`, `follow_up_type` discriminator (`commit`|`pr`), conditional `commit_sha`/`pr_number`, `recorded_by`, `recorded_at`. A `model_validator` enforces the commit-vs-pr conditional-required rule (mirrors the producer's runtime guard).
- Both models use `ConfigDict(frozen=True, extra="forbid")`, mirroring the sibling `MissionClosedPayload`/`MissionOriginBoundPayload` pattern.
- Package-root re-exports (constants + payload classes) and `_EVENT_TYPE_TO_MODEL` registry entries. No JSON-schema entry yet (the schema layer is optional secondary, same as `MissionOriginBound`).

## Contract fidelity

Payload field names/types match the producer call sites **exactly** (verified against `lifecycle_events.py` and `mission-lifecycle-dispatch-drg-closeout-01KV0S99/data-model.md`): required fields are required, nullable fields (`cleared_merge`, `commit_sha`, `pr_number`) are optional.

## Tests / gates

- New unit tests in `tests/unit/test_lifecycle.py` (valid payloads, missing-required rejection, commit-vs-pr discriminator, frozen/extra-forbid, round-trip, and conformance-registry presence).
- `pytest`: **2116 passed**.
- `mypy src/`: clean.
- `ruff`: zero new findings (pre-existing repo debt unchanged at 70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)